### PR TITLE
Exact release command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,6 @@ jobs:
       - name: Build
         run: pnpm run build
       - name: Publish to npm
-        run: npm publish --provenance
+        run: pnpm --filter=./ --no-git-checks publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embed-typescript-compiler",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "Embed TypeScript Compiler in your NodeJS/Browser Application",
   "main": "src/index.ts",
   "scripts": {
@@ -14,8 +14,15 @@
     "nodejs",
     "browser"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/samchon/embed-typescript-compiler"
+  },
   "author": "Jeongho Nam",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/samchon/embed-typescript-compiler/issues"
+  },
   "peerDependencies": {
     "typescript": ">=5.0.0 <6.0.0"
   },
@@ -34,7 +41,8 @@
       "embed-typescript-compiler": "lib/cli/index.js"
     },
     "main": "lib/index.js",
-    "typings": "lib/index.d.ts"
+    "typings": "lib/index.d.ts",
+    "access": "public"
   },
   "files": [
     "lib",


### PR DESCRIPTION
This pull request introduces updates to the release workflow, versioning, and metadata of the `embed-typescript-compiler` package. The key changes include switching to `pnpm` for publishing, updating the package version, and enhancing the `package.json` metadata with repository and issue tracking information.

### Workflow improvements:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L26-R26): Updated the `Publish to npm` step to use `pnpm` with specific flags (`--filter=./ --no-git-checks`) instead of `npm` for publishing, ensuring consistency with the project's package manager.

### Versioning:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Changed the version from `1.0.0` to `0.2.0`, reflecting a downgrade to align with semantic versioning and the current stage of the project.

### Metadata enhancements:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17-R25): Added a `repository` field with the project's GitHub URL and a `bugs` field for issue tracking, improving discoverability and support.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L37-R45): Included an `access` field set to `public` under the `publishConfig` section, ensuring the package is published as a public package.